### PR TITLE
removing links in home page

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 Mapzen Mobility is a toolkit for multimodal transportation, powered by open-source software and open data.
 
-[Mapzen Turn-by-Turn](turn-by-turn-overview.md) guides you between points by car, bike, foot, and multimodal combinations involving walking and riding public transit. Your apps can use Mapzen Turn-by-Turn to plan multimodal journeys with narratives to guide users by text and by voice. Mapzen Turn-by-Turn draws data from OpenStreetMap and from [Transitland](https://transit.land/documentation/), the open transit data aggregation project that Mapzen sponsors.
+Mapzen Turn-by-Turn guides you between points by car, bike, foot, and multimodal combinations involving walking and riding public transit. Your apps can use Mapzen Turn-by-Turn to plan multimodal journeys with narratives to guide users by text and by voice. Mapzen Turn-by-Turn draws data from OpenStreetMap and from [Transitland](https://transit.land/documentation/), the open transit data aggregation project that Mapzen sponsors.
 
-Trying to run more than one errand in the day or start your own delivery service? The [Optimized Route service](optimized_route/api-reference.md) computes the times and distances between many origins and destinations and provides you with an [optimized path between the locations](https://simple.wikipedia.org/wiki/Travelling_salesman_problem).
+Trying to run more than one errand in the day or start your own delivery service? The Optimized Route service computes the times and distances between many origins and destinations and provides you with an optimized path between the locations.
 
-If you want only a table of the times and distances, start with [Mapzen Matrix](matrix/api-reference). 
+If you want only a table of the times and distances, start with Mapzen Matrix. 


### PR DESCRIPTION
For some reason, these links are broken. See https://github.com/mapzen/mapzen-docs-generator/issues/211

I'm going to pull them out while we figure out why this is happening. I'm also removing the link to Wikipedia because it takes people out of the docs too soon (I think Transitland is OK because it's our project).