### PR TITLE
Correct `polygon` parameter to `polygons`

### DIFF
--- a/isochrone/api-reference.md
+++ b/isochrone/api-reference.md
@@ -42,7 +42,7 @@ Mapzen Isochrone uses the `auto`, `bicycle`, `pedestrian`, and `multimodal` cost
 | `date_time` | The local date and time at the location.<ul><li>`type`<ul><li>0 - Current departure time.</li><li>1 - Specified departure time</li><li>2 - Specified arrival time. This is not yet implemented for multimodal costing method.</li></ul></li><li>`value` - the date and time specified in ISO 8601 format (YYYY-MM-DDThh:mm) in the local time zone of departure or arrival. For example, "2016-07-03T08:06"</li></ul> |
 | `id` | Name of the isochrone request. If `id` is specified, the name is returned with the response. |
 | `contours` | A JSON array of contour objects with the time in minutes and color to use for each isochrone contour. <ul><li>`time` - The time in minutes for the contour.<li>`color` - The color for the output of the contour. Specify it as a [Hex value](http://www.w3schools.com/colors/colors_hexadecimal.asp), but without the `#`, such as `"color":"ff0000"` for red. If no color is specified, the isochrone service will assign a default color to the output.</li></ul>  |
-| `polygon` | A Boolean value to determine whether to return geojson polygons or linestrings as the contours. The default is `false`, which returns lines; when `true`, polygons are returned. Note: When `polygon` is `true`, any contour that forms a ring is returned as a polygon. |
+| `polygons` | A Boolean value to determine whether to return geojson polygons or linestrings as the contours. The default is `false`, which returns lines; when `true`, polygons are returned. Note: When `polygons` is `true`, any contour that forms a ring is returned as a polygon. |
 | `denoise` | A floating point value from `0` to `1` (default of `1`) which can be used to remove smaller contours. A value of `1` will only return the largest contour for a given time value. A value of `0.5` drops any contours that are less than half the area of the largest contour in the set of contours for that same time value. |
 | `generalize` | A floating point value in meters used as the tolerance for [Douglas-Peucker](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm) generalization. Note: Generalization of contours can lead to self-intersections, as well as intersections of adjacent contours. |
 
@@ -50,7 +50,7 @@ Mapzen Isochrone uses the `auto`, `bicycle`, `pedestrian`, and `multimodal` cost
 
 In the service response, the isochrone contours are returned as [GeoJSON](http://geojson.org/), which can be integrated into mapping applications.
 
-The contours are calculated using rasters and are returned as either polygon or line features, depending on your input setting for the `polygon` parameter. If an isochrone request has been named using the optional `&id=` input, then the `id` is returned as a name property for the feature collection within the GeoJSON response.
+The contours are calculated using rasters and are returned as either polygon or line features, depending on your input setting for the `polygons` parameter. If an isochrone request has been named using the optional `&id=` input, then the `id` is returned as a name property for the feature collection within the GeoJSON response.
 
 See the [HTTP return codes](https://mapzen.com/documentation/mobility/turn-by-turn/api-reference//#return-codes-and-conditions) for more on messages you might receive from the service.
 


### PR DESCRIPTION
When using the Isochrone API, the correct way to request a polygonal GeoJSON response is to use the `polygons` parameter but the documentation refers to `polygon`, which does nothing.

This request (using `polygon`) returns a `LineString` feature: https://matrix.mapzen.com/isochrone?json=%7B%22locations%22%3A%20%5B%7B%22lat%22%3A%2243.07227%22%2C%22lon%22%3A%22-89.39208%22%7D%5D%2C%22costing%22%3A%22pedestrian%22%2C%22contours%22%3A%5B%7B%22time%22%3A5%7D%5D%2C%22polygon%22%3Atrue%7D

This request (using `polygons`) returns a `Polygon` feature: https://matrix.mapzen.com/isochrone?json=%7B%22locations%22%3A%20%5B%7B%22lat%22%3A%2243.07227%22%2C%22lon%22%3A%22-89.39208%22%7D%5D%2C%22costing%22%3A%22pedestrian%22%2C%22contours%22%3A%5B%7B%22time%22%3A5%7D%5D%2C%22polygons%22%3Atrue%7D