### PR TITLE
Fix broken image link path

### DIFF
--- a/isochrone/api-reference.md
+++ b/isochrone/api-reference.md
@@ -6,7 +6,7 @@ Isochrone maps share some of the same concepts and terminology with familiar top
 
 This is an example of isochrones showing the travel times by driving from a location in Melbourne, as depicted in Mobility Explorer.
 
-![Isochrones for travel times by driving in Melbourne from Mobility Explorer](/images/melbourne_explorer.png)
+![Isochrones for travel times by driving in Melbourne from Mobility Explorer](/images/melbourne-isochrones.png)
 
 ## Inputs of the Isochrone service
 


### PR DESCRIPTION
Final version of the file was named melbourne-isochrones.png, so this change fixes the broken image link.

cc @kkowalsky thanks for the heads up