### PR TITLE
Point people at valhalla, not thor.

### DIFF
--- a/matrix/api-reference.md
+++ b/matrix/api-reference.md
@@ -2,7 +2,7 @@
 
 The Time-Distance Matrix service provides a quick computation of time and distance between a set of locations and returns them to you in the resulting matrix table.
 
-The Time-Distance matrix service is in active development. You can follow the [Mapzen blog](https://mapzen.com/blog) to get updates. To report software issues or suggest enhancements, open an issue in the [Thor GitHub repository](https://github.com/valhalla/thor/issues) or send a message to [routing@mapzen.com](mailto:routing@mapzen.com).
+The Time-Distance matrix service is in active development. You can follow the [Mapzen blog](https://mapzen.com/blog) to get updates. To report software issues or suggest enhancements, open an issue in the [Valhalla GitHub repository](https://github.com/valhalla/valhalla/issues) or send a message to [routing@mapzen.com](mailto:routing@mapzen.com).
 
 ## API keys and service limits
 


### PR DESCRIPTION
Why point to a repo being provided for "hysterical raisins" only? I don't know if you want to the change the routing@mapzen email address to valhalla@mapzen but maybe you do.