### PR TITLE
update elevation headings, change repo to joerd

### DIFF
--- a/elevation/elevation-service.md
+++ b/elevation/elevation-service.md
@@ -1,10 +1,10 @@
-#Elevation service API reference
+# Elevation service API reference
 
 Mapzen's elevation service is an open-source web API (and C++ library) that provides digital elevation model (DEM) data as the result of a query. The elevation service data has many applications when combined with other routing and navigation data, including computing the steepness of edges or generating an elevation profile along a route. This page documents the inputs and outputs to the service.
 
 The elevation service is in active development. You can follow the [Mapzen blog](https://mapzen.com/blog) to get updates. To report software issues or suggest enhancements, open an issue in [Skadi GitHub repository](https://github.com/valhalla/skadi/issues). If you find a unique use for the elevation service, let the developers know at [routing@mapzen.com](mailto:routing@mapzen.com)!
 
-##API keys and service limits
+## API keys and service limits
 
 To use Mapzen's elevation service, you must first obtain a Mapzen API key. Sign in at https://mapzen.com/developers to create and manage your API keys.
 
@@ -12,7 +12,7 @@ This is a shared service. As such, there are limitations on the number of sampli
 
 Limits may be increased in the future, but you can contact routing@mapzen.com if you encounter rate limit status messages and need higher limits in the meantime.
 
-##Inputs of the elevation service
+## Inputs of the elevation service
 
 The elevation service currently has a single action, `/height?`, that can be requested. The `height` provides the elevation at a set of input locations, which are specified as either a `shape` or an `encoded_polyline`. The shape option uses an ordered list of one or more locations within a JSON array, while an encoded polyline stores multiple locations within a single string. If you include a `range` parameter and set it to `true`, both the height and cumulative distance are returned for each point.
 
@@ -22,7 +22,7 @@ There is an option to name your elevation request.  You can do this by appending
 
 Note that you must append your own [API key](https://mapzen.com/developers) to the URL, following `&api_key=` at the end.
 
-###Use a shape list for input locations
+### Use a shape list for input locations
 
 A `shape` request must include a latitude and longitude in decimal degrees, and the locations are visited in the order specified. The input coordinates can come from many input sources, such as a GPS location, a point or a click on a map, a geocoding service, and so on.
 
@@ -45,7 +45,7 @@ Without the `range`, the result looks something like this, with only a `height`:
 
     {"shape":[{"lat":40.712433,"lon":-76.504913},{"lat":40.712276,"lon":-76.605263},{"lat":40.712124,"lon":-76.805695},{"lat":40.722431,"lon":-76.884918},{"lat":40.812275,"lon":-76.905258},{"lat":40.912121,"lon":-76.965691}],"height":[307,272,204,204,180,198]}
 
-###Use an encoded polyline for input locations
+### Use an encoded polyline for input locations
 
 The `encoded_polyline` parameter is a string of a polyline-encoded, with six degrees of precision, shape and has the following parameters.
 
@@ -59,7 +59,7 @@ Here is an example `encoded_polyline` request:
 
     elevation.mapzen.com/height?json={"range":true,"encoded_polyline":"s{cplAfiz{pCa]xBxBx`AhC|gApBrz@{[hBsZhB_c@rFodDbRaG\\ypAfDec@l@mrBnHg|@?}TzAia@dFw^xKqWhNe^hWegBfvAcGpG{dAdy@_`CpoBqGfC_SnI{KrFgx@?ofA_Tus@c[qfAgw@s_Agc@}^}JcF{@_Dz@eFfEsArEs@pHm@pg@wDpkEx\\vjT}Djj@eUppAeKzj@eZpuE_IxaIcF~|@cBngJiMjj@_I`HwXlJuO^kKj@gJkAeaBy`AgNoHwDkAeELwD|@uDfC_i@bq@mOjUaCvDqBrEcAbGWbG|@jVd@rPkAbGsAfDqBvCaIrFsP~RoNjWajBlnD{OtZoNfXyBtE{B~HyAtEsFhL_DvDsGrF_I`HwDpGoH|T_IzLaMzKuOrFqfAbPwCl@_h@fN}OnI"}&api_key=mapzen-xxxxxx
 
-###Get height and distance with the range parameter
+### Get height and distance with the range parameter
 
 The `range` parameter is a boolean value that controls whether or not the returned array is one-dimensional (height only) or two-dimensional (with a range and height). This can be used to generate a graph along a route, because a 2D-array has values for x (the range) and y (the height) at each shape point. Steepness or gradient can also be computed from a profile request.
 
@@ -76,7 +76,7 @@ The `range` is optional and assumed to be `false` if omitted.
 | `id` | Name your elevation request. If `id` is specified, the naming will be sent thru to the response. |
 
 
-##Outputs of the elevation service
+## Outputs of the elevation service
 
 If an elevation request has been named using the optional `&id=` input, then the name will be returned as a string `id`.
 
@@ -91,6 +91,6 @@ The profile results are returned with the form of shape (shape points or encoded
 | `y coordinate` | The height or elevation of the associated latitude, longitude pair. The height is returned as `null` if no height data exists for a given location. |
 | `height` | An array of height for the associated latitude, longitude coordinates. |
 
-##Data sources and known issues
+## Data sources and known issues
 
-Currently, the underlying data sources for the service are a mix of [SRTM](http://www2.jpl.nasa.gov/srtm/), [GMTED](http://topotools.cr.usgs.gov/gmted_viewer/), [NED](https://nationalmap.gov/elevation.html) and [ETOPO1](https://www.ngdc.noaa.gov/mgg/global/) DEMs. These sets provide global coverage at varying resolutions up to approximately 10 meters. It should be noted that both SRTM and GMTED fill oceans and other bodies of water with a value of zero to indicate mean sea level; in these areas, ETOPO1 provides bathymetry (as well as in regions which are not covered by NED, SRTM and GMTED). Many other classical DEM-related issues occur in these datasets. It is not uncommon to see large variations in elevation in areas with large buildings and other such structures. We are considering how to best integrate other sources such as NRCAN and are always looking for better datasets. If you find any data issues or can suggest any supplemental open datasets, please let us know by filing an issue in the [Valhalla GitHub repository](https://github.com/valhalla/valhalla/issues).
+Currently, the underlying data sources for the service are a mix of [SRTM](http://www2.jpl.nasa.gov/srtm/), [GMTED](http://topotools.cr.usgs.gov/gmted_viewer/), [NED](https://nationalmap.gov/elevation.html) and [ETOPO1](https://www.ngdc.noaa.gov/mgg/global/) DEMs. These sets provide global coverage at varying resolutions up to approximately 10 meters. It should be noted that both SRTM and GMTED fill oceans and other bodies of water with a value of zero to indicate mean sea level; in these areas, ETOPO1 provides bathymetry (as well as in regions which are not covered by NED, SRTM and GMTED). Many other classical DEM-related issues occur in these datasets. It is not uncommon to see large variations in elevation in areas with large buildings and other such structures. We are considering how to best integrate other sources such as NRCAN and are always looking for better datasets. If you find any data issues or can suggest any supplemental open datasets, please let us know by filing an issue in this [GitHub repository](https://github.com/tilezen/joerd/issues).


### PR DESCRIPTION
@kevinkreiser updated this to reflect ETOPO1's usage instead of GEBCO.

This adds a couple of little changes:
1) GitHub-flavored markdown now requires a space between #s and text to work properly.
2) changes the repo for suggestions to Tilezen/Joerd instead of Valhalla.