### PR TITLE
Remove reference to map matching

### DIFF
--- a/explorer/overview.md
+++ b/explorer/overview.md
@@ -2,4 +2,4 @@
 
 [Mobility Explorer](https://mapzen.com/mobility/explorer) helps you understand transportation networks around the world. Search for a place or browse the map, and use the buttons to view transit routes, stops, and operators.
 
-Use Mobility Explorer to query and visualize transit data from [Transitland](https://transit.land), a community-edited, open transit data aggregation project that Mapzen sponsors, and to analyze access using other Mapzen Mobility services, including [Mapzen Isochrone](https://mapzen.com/documentation/mobility/isochrone/api-reference/) and [Mapzen Map Matching](https://mapzen.com/documentation/mobility/map-matching/api-reference/).
+Use Mobility Explorer to query and visualize transit data from [Transitland](https://transit.land), a community-edited, open transit data aggregation project that Mapzen sponsors, and to analyze access using other Mapzen Mobility services, including [Mapzen Isochrone](https://mapzen.com/documentation/mobility/isochrone/api-reference/).


### PR DESCRIPTION
A user found this reference to the Map Matching API, but was confused when it was a broken link. This removes the link from the docs for now.