### PR TITLE
Add links to new sample demos

### DIFF
--- a/api-reference.md
+++ b/api-reference.md
@@ -2,6 +2,8 @@
 
 Mapzen Turn-by-Turn, powered by the Valhalla engine, is an open-source routing service that lets you integrate routing and navigation into a web or mobile application.
 
+For an interactive demo, see https://mapzen.com/products/turn-by-turn/.
+
 The default logic for the OpenStreetMap tags, keys, and values used when routing are documented on an [OSM wiki page](http://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Valhalla).
 
 ## Inputs of a route

--- a/decoding.md
+++ b/decoding.md
@@ -1,8 +1,8 @@
 # Decode a route shape
 
-Mapzen Turn-by-Turn uses the Google Maps encoded polyline format to store a series of latitude, longitude coordinates as a single string. Polyline encoding greatly reduces the size of the route response, especially for longer routes. A description is found here: [polyline encoding](https://developers.google.com/maps/documentation/utilities/polylinealgorithm).
+Mapzen Turn-by-Turn uses the encoded polyline format to store a series of latitude, longitude coordinates as a single string. Polyline encoding greatly reduces the size of the route response, especially for longer routes. A description is found here: [polyline encoding](https://developers.google.com/maps/documentation/utilities/polylinealgorithm).
 
-Note that Mapzen Turn-by-Turn uses six digits of decimal precision, rather than five as referenced in the Google algorithms documentation.
+Note that Mapzen APIs use six digits of decimal precision, rather than five as referenced in the Google algorithms documentation.
 
 Below are some sample algorithms to decode the string to create a list of latitude,longitude coordinates.
 

--- a/elevation/elevation-service.md
+++ b/elevation/elevation-service.md
@@ -1,6 +1,10 @@
 # Elevation service API reference
 
-Mapzen's elevation service is an open-source web API (and C++ library) that provides digital elevation model (DEM) data as the result of a query. The elevation service data has many applications when combined with other routing and navigation data, including computing the steepness of edges or generating an elevation profile along a route.
+Mapzen's elevation service provides digital elevation model (DEM) data as the result of a query. The elevation service data has many applications when combined with other routing and navigation data, including computing the steepness of edges or generating an elevation profile along a route.
+
+For example, you can get elevation data for a point, a trail, or a trip. You might use the results to consider hills for your bicycle trip, or when estimating battery usage for trips in electric vehicles.
+
+For an interactive demo, see https://mapzen.com/data/elevation.
 
 ## Inputs of the elevation service
 

--- a/elevation/index.md
+++ b/elevation/index.md
@@ -1,1 +1,5 @@
-Mapzen's elevation service is an open-source web API (and C++ library) that provides digital elevation model (DEM) data as the result of a query. The elevation service data has many applications when combined with other routing and navigation data, including computing the steepness of edges or generating an elevation profile along a route. 
+Mapzen's elevation service provides digital elevation model (DEM) data as the result of a query. The elevation service data has many applications when combined with other routing and navigation data, including computing the steepness of edges or generating an elevation profile along a route. 
+
+For example, you can get elevation data for a point, a trail, or a trip. You might use the results to consider hills for your bicycle trip, or when estimating battery usage for trips in electric vehicles.
+
+For an interactive demo, see https://mapzen.com/data/elevation.

--- a/index.md
+++ b/index.md
@@ -1,13 +1,13 @@
 Mapzen Mobility is a toolkit for multimodal transportation, powered by open-source software and open data.
 
-Mapzen Turn-by-Turn guides you between points by car, bike, foot, and multimodal combinations involving walking and riding public transit. Your apps can use Mapzen Turn-by-Turn to plan multimodal journeys with narratives to guide users by text and by voice. Mapzen Turn-by-Turn draws data from OpenStreetMap and from [Transitland](https://transit.land/documentation/), the open transit data aggregation project that Mapzen sponsors.
+[Mapzen Turn-by-Turn](https://mapzen.com/products/turn-by-turn) guides you between points by car, bike, foot, and multimodal combinations involving walking and riding public transit. Your apps can use Mapzen Turn-by-Turn to plan multimodal journeys with narratives to guide users by text and by voice. Mapzen Turn-by-Turn draws data from OpenStreetMap and from [Transitland](https://transit.land/documentation/), the open transit data aggregation project that Mapzen sponsors.
 
-Trying to run more than one errand in the day or start your own delivery service? The Optimized Route service computes the times and distances between many origins and destinations and provides you with an optimized path between the locations.
+Trying to run more than one errand in the day or start your own delivery service? The [Optimized Route](https://mapzen.com/products/optimized-route/) service computes the times and distances between many origins and destinations and provides you with an optimized path between the locations.
 
-If you want only a table of the times and distances, start with Mapzen Matrix. 
+If you want only a table of the times and distances, start with [Mapzen Matrix](https://mapzen.com/products/time-distance-matrix/).
 
-Use Mapzen Isochrone to get a computation of areas that are reachable within specified time periods from a location or set of locations. 
+Use [Mapzen Isochrone](https://mapzen.com/products/isochrone/) to get a computation of areas that are reachable within specified time periods from a location or set of locations.
 
-Mapzen Map Matching matches coordinates to known roads so you can turn a path into a route with narrative instructions and get the attribute values from that matched line.
+[Mapzen Map Matching](https://mapzen.com/products/map-matching/) matches coordinates to known roads so you can turn a path into a route with narrative instructions and get the attribute values from that matched line.
 
 Use [Mobility Explorer](https://mapzen.com/mobility/explorer/) to query and visualize transit data from Transitland and analyze access using Mapzen Mobility services.

--- a/isochrone/api-reference.md
+++ b/isochrone/api-reference.md
@@ -1,6 +1,8 @@
 # Isochrone service API reference
 
-An isochrone is a line that connects points of equal travel time about a given location, from the Greek roots of `iso` for equal and `chrone` for time. The Mapzen Isochrone service computes areas that are reachable within specified time intervals from a location, and returns the reachable regions as contours of polygons or lines that you can display on a map. You can use [Mobility Explorer](https://mapzen.com/mobility/explorer) to experiment with Mapzen Isochrone, or visit https://mapzen.com/products/isochrone/ for sample maps.
+An isochrone is a line that connects points of equal travel time about a given location, from the Greek roots of `iso` for equal and `chrone` for time. The Mapzen Isochrone service computes areas that are reachable within specified time intervals from a location, and returns the reachable regions as contours of polygons or lines that you can display on a map.
+
+For an interactive demo, you can use [Mobility Explorer](https://mapzen.com/mobility/explorer) to experiment with Mapzen Isochrone, or visit https://mapzen.com/products/isochrone/ for sample maps.
 
 Isochrone maps share some of the same concepts and terminology with familiar topographic maps, which depict contour lines for points of equal elevation. For this reason other terms common in topography apply, such as contours or isolines.
 

--- a/isochrone/api-reference.md
+++ b/isochrone/api-reference.md
@@ -1,6 +1,6 @@
 # Isochrone service API reference
 
-An isochrone is a line that connects points of equal travel time about a given location, from the Greek roots of `iso` for equal and `chrone` for time. The Mapzen Isochrone service computes areas that are reachable within specified time intervals from a location, and returns the reachable regions as contours of polygons or lines that you can display on a map. You can use [Mobility Explorer](https://mapzen.com/mobility/explorer) to see a demonstration of the Isochrone service.
+An isochrone is a line that connects points of equal travel time about a given location, from the Greek roots of `iso` for equal and `chrone` for time. The Mapzen Isochrone service computes areas that are reachable within specified time intervals from a location, and returns the reachable regions as contours of polygons or lines that you can display on a map. You can use [Mobility Explorer](https://mapzen.com/mobility/explorer) to experiment with Mapzen Isochrone, or visit https://mapzen.com/products/isochrone/ for sample maps.
 
 Isochrone maps share some of the same concepts and terminology with familiar topographic maps, which depict contour lines for points of equal elevation. For this reason other terms common in topography apply, such as contours or isolines.
 

--- a/map-matching/api-reference.md
+++ b/map-matching/api-reference.md
@@ -2,6 +2,8 @@
 
 With the Mapzen Map Matching service, you can match coordinates, such as GPS locations, to roads and paths that have been mapped in OpenStreetMap. By doing this, you can turn a path into a route with narrative instructions and also get the attribute values from that matched line.
 
+You can see a demo at https://mapzen.com/products/map-matching/.
+
 There are two separate Map Matching calls that perform different operations on an input set of latitude,longitude coordinates. The `trace_route` action returns the shape snapped to the road network and narrative directions, while `trace_attributes` returns detailed attribution along the portion of the route.
 
 It is important to note that all service requests should be *POST* because `shape` or `encoded_polyline` can be fairly large.

--- a/map-matching/api-reference.md
+++ b/map-matching/api-reference.md
@@ -2,7 +2,7 @@
 
 With the Mapzen Map Matching service, you can match coordinates, such as GPS locations, to roads and paths that have been mapped in OpenStreetMap. By doing this, you can turn a path into a route with narrative instructions and also get the attribute values from that matched line.
 
-For an interactive demo, you can use [Mobility Explorer](https://mapzen.com/mobility/explorer) to experiment with Mapzen Map Matching and try tracing your own data, or visit https://mapzen.com/products/map-matching/ for a sample.
+For an interactive demo, you can use [Mobility Explorer](https://mapzen.com/mobility/explorer) to experiment and try tracing your own data, or visit https://mapzen.com/products/map-matching/ for a sample.
 
 There are two separate Map Matching calls that perform different operations on an input set of latitude,longitude coordinates. The `trace_route` action returns the shape snapped to the road network and narrative directions, while `trace_attributes` returns detailed attribution along the portion of the route.
 

--- a/map-matching/api-reference.md
+++ b/map-matching/api-reference.md
@@ -2,7 +2,7 @@
 
 With the Mapzen Map Matching service, you can match coordinates, such as GPS locations, to roads and paths that have been mapped in OpenStreetMap. By doing this, you can turn a path into a route with narrative instructions and also get the attribute values from that matched line.
 
-You can see a demo at https://mapzen.com/products/map-matching/.
+For an interactive demo, you can use [Mobility Explorer](https://mapzen.com/mobility/explorer) to experiment with Mapzen Map Matching and try tracing your own data, or visit https://mapzen.com/products/map-matching/ for a sample.
 
 There are two separate Map Matching calls that perform different operations on an input set of latitude,longitude coordinates. The `trace_route` action returns the shape snapped to the road network and narrative directions, while `trace_attributes` returns detailed attribution along the portion of the route.
 

--- a/matrix/api-reference.md
+++ b/matrix/api-reference.md
@@ -2,6 +2,8 @@
 
 The Time-Distance Matrix service provides a quick computation of time and distance between a set of locations and returns them to you in the resulting matrix table.
 
+For an interactive demo, see https://mapzen.com/products/time-distance-matrix/.
+
 ## Matrix service actions
 
 You can request the following actions from the Time-Distance Matrix service: `/one_to_many?`, `/many_to_one?`, `/many_to_many?` or `/sources_to_targets?`. These queries compute different types of matrices: a row matrix for a `one_to_many`, a column matrix for a `many_to_one`, a square matrix for a `many_to_many` or any of the three matrices using `sources_to_targets`.  

--- a/matrix/api-reference.md
+++ b/matrix/api-reference.md
@@ -108,4 +108,6 @@ See the [HTTP return codes](https://mapzen.com/documentation/turn-by-turn/api-re
 
 ## Sample matrix demonstration
 
-If you want to see the results of the Time-Distance Matrix service, try this [sample demonstration utility](http://valhalla.github.io/demos/matrix/) and [code](https://github.com/valhalla/demos/tree/gh-pages/matrix) that shows integration of the Time-Distance Matrix results into a map and a table.  Please note that this demo is not using the `sources_to_targets` action call.
+If you want to see the results of the Time-Distance Matrix service, try this [interactive demo](https://mapzen.com/products/optimized-route).
+
+The [code](https://github.com/valhalla/demos/tree/gh-pages/matrix) shows integration of the Time-Distance Matrix results into a map and a table. This demo does not use the `sources_to_targets` action call.

--- a/optimized_route/api-reference.md
+++ b/optimized_route/api-reference.md
@@ -2,6 +2,8 @@
 
 The Optimized Route service provides a quick computation of time and distance between a set of location sources and location targets and returns them in an optimized route order, along with the shape.
 
+For an interactive demo, see https://mapzen.com/products/optimized-route.
+
 ## Optimized route service action
 
 You can request the following action from the Optimized Route service: `/optimized_route?`. Since an optimized route is really an extension of the `many_to_many` matrix, the first step is to compute a cost matrix by sending a `many_to_many` matrix request.  Then, we send our resulting cost matrix (resulting time or distance) to the optimizer which will return our optimized path.
@@ -70,7 +72,3 @@ This is an example which it returns: `400::Location at index 3 is unreachable`
 ```
 
 See the [HTTP return codes](https://mapzen.com/documentation/turn-by-turn/api-reference/#return-codes-and-conditions) for more on messages you might receive from the service.
-
-## Sample optimized route demonstration
-
-If you want to see the results of the Optimized Route service, please try out the sample demonstration utility: [Optimized Route Test Utility](http://valhalla.github.io/demos/optimized_route/index.html#loc=13,40.748600,-73.969000)


### PR DESCRIPTION
Fixes #184 

Sum:
- adds links to demos on product pages
- replaces links to github.io with mapzen.com
- takes emphasis off Google in encoded polyline doc (many support tickets where people report that their code works in Google's encoder test app, which is not six digits)
- adds some examples to the elevation intro content